### PR TITLE
Add support for stream_id

### DIFF
--- a/lib/cassandra/cql.lua
+++ b/lib/cassandra/cql.lua
@@ -10,7 +10,6 @@ Notes:
   - does not implement SUPPORTED results parsing and OPTIONS messages
   - does not implement EVENTS parsing
   - does not implement compression
-  - does not set stream ids for frames
   - does not implement no_metadata query flag and ROWS results flag
   - does not implement decimal data type
   - does not implement parsing of specific error codes
@@ -961,10 +960,15 @@ do
 
     header:write_byte(flags)
 
+    local stream_id = 0
+    if self.opts and self.opts.stream_id then
+      stream_id = self.opts.stream_id
+    end
+
     if version < 3 then
-      header:write_byte(0)       -- stream_id
+      header:write_byte(stream_id)
     else
-      header:write_short(0)      -- stream_id
+      header:write_short(stream_id)
     end
 
     header:write_byte(self.op_code)

--- a/lib/cassandra/init.lua
+++ b/lib/cassandra/init.lua
@@ -128,12 +128,14 @@ function _Host.new(opts)
   local sock, err = socket.tcp()
   if err then return nil, err end
 
+  local protocol_version = opts.protocol_version or cql.def_protocol_version
+
   local host = {
     sock = sock,
     host = opts.host or '127.0.0.1',
     port = opts.port or 9042,
     keyspace = opts.keyspace,
-    protocol_version = opts.protocol_version or cql.def_protocol_version,
+    protocol_version = protocol_version,
     ssl = opts.ssl,
     verify = opts.verify,
     cert = opts.cert,
@@ -155,28 +157,34 @@ function _Host:send(request)
   local sent, err = self.sock:send(frame)
   if not sent then return nil, err end
 
-  -- receive frame version byte
-  local v_byte, err = self.sock:receive(1)
-  if not v_byte then return nil, err end
+  while true do
+    -- receive frame version byte
+    local v_byte, err = self.sock:receive(1)
+    if not v_byte then return nil, err end
 
-  -- -1 because of the v_byte we just read
-  local version, n_bytes = cql.frame_reader.version(v_byte)
+    -- -1 because of the v_byte we just read
+    local version, n_bytes = cql.frame_reader.version(v_byte)
 
-  -- receive frame header
-  local header_bytes, err = self.sock:receive(n_bytes)
-  if not header_bytes then return nil, err end
+    -- receive frame header
+    local header_bytes, err = self.sock:receive(n_bytes)
+    if not header_bytes then return nil, err end
 
-  local header = cql.frame_reader.read_header(version, header_bytes)
+    local header = cql.frame_reader.read_header(version, header_bytes)
 
-  -- receive frame body
-  local body_bytes
-  if header.body_length > 0 then
-    body_bytes, err = self.sock:receive(header.body_length)
-    if not body_bytes then return nil, err end
+    -- receive frame body
+    local body_bytes
+    if header.body_length > 0 then
+      body_bytes, err = self.sock:receive(header.body_length)
+      if not body_bytes then return nil, err end
+    end
+
+    -- Only return a response  with a matching stream_id
+    -- and drop everything else
+    if not request.opts or not request.opts.stream_id or request.opts.stream_id == header.stream_id then
+      -- res, err, cql_err_code
+      return cql.frame_reader.read_body(header, body_bytes)
+    end
   end
-
-  -- res, err, cql_err_code
-  return cql.frame_reader.read_body(header, body_bytes)
 end
 
 local function send_startup(self)

--- a/spec/01-unit/03-cql_spec.lua
+++ b/spec/01-unit/03-cql_spec.lua
@@ -166,6 +166,7 @@ for protocol_version = 2, 3 do
 
   describe("CQL requests", function()
     local requests = cql.requests
+    local consistencies = cql.consistencies
 
     it("sanity", function()
       local r = requests.query.new("SELECT * FROM peers")
@@ -189,6 +190,14 @@ for protocol_version = 2, 3 do
 
         local frame3 = r:build_frame(protocol_version)
         assert.matches("SELECT key FROM local", frame3, nil, true)
+      end)
+      it("sets the stream_id if provided", function()
+        local r = requests.query.new("SELECT * FROM local")
+        r.opts = {stream_id = 255, consistency = consistencies.one}
+        local frame = r:build_frame(protocol_version)
+
+        local header = cql.frame_reader.read_header(protocol_version, string.sub(frame, 2, -1))
+        assert.equal(255, header.stream_id)
       end)
     end)
 

--- a/spec/01-unit/04-host_spec.lua
+++ b/spec/01-unit/04-host_spec.lua
@@ -1,0 +1,87 @@
+local cassandra = require "cassandra"
+local cql = require "cassandra.cql"
+
+describe("_Host", function()
+  describe("new", function()
+    it("sets max_stream_ids to the right value", function()
+      local host_v2, err = cassandra.new({protocol_version = 2})
+      assert.is_nil(err)
+      assert.are.equal(2^7-1, host_v2.max_stream_ids)
+
+      local host_v3, err = cassandra.new({protocol_version = 3})
+      assert.is_nil(err)
+      assert.are.equal(2^15-1, host_v3.max_stream_ids)
+    end)
+  end)
+
+  describe("send", function()
+
+    local function mock_request()
+      local r = cql.requests.startup.new()
+      return mock(r)
+    end
+
+    local function mock_host()
+      local host, err = cassandra.new()
+      assert.is_nil(err)
+      stub(host.sock, "send")
+      stub(host.sock, "receive")
+      return host
+    end
+
+    it("sets stream_id without overriding existing opts", function()
+      local req = mock_request()
+      local host = mock_host()
+      req.opts = {custom = "option"}
+
+      local _, err = host:send(req)
+      assert.is_nil(err)
+      assert.are.same({custom = "option", stream_id = 1}, req.opts)
+    end)
+
+    it("sets stream_id if there are no existing opts", function()
+      local req = mock_request()
+      local host = mock_host()
+
+      local _, err = host:send(req)
+      assert.is_nil(err)
+      assert.are.same({stream_id = 1}, req.opts)
+    end)
+
+    it("restarts from 0 once all ids have been used", function()
+      local req = mock_request()
+      local host = mock_host()
+      host.current_stream_id = host.max_stream_ids
+
+      local _, err = host:send(req)
+      assert.is_nil(err)
+      assert.are.equal(0, host.current_stream_id)
+    end)
+
+    it("retries if response stream_id doesn't match", function()
+      local req = mock_request()
+      local host = mock_host()
+      host.sock.send = function() return true, nil end
+      host.sock.receive = function() return "foobar", nil end
+      local stream_id = 4
+      local read_header_count = 0
+
+      cql.frame_reader = {
+        version = function(_) return 3 end,
+        read_header = function(_)
+          read_header_count = read_header_count + 1
+          stream_id = stream_id - 1
+          return {stream_id = stream_id, body_length = 0}
+        end,
+        read_body = function(_, _) return "body" end
+      }
+
+      local res, err = host:send(req)
+      assert.is_nil(err)
+      -- The first 2 times the stream_id doesn't match (3 & 2)
+      -- The third time is 1 so the function should exit correctly
+      assert.are.equal(3, read_header_count)
+      assert.are.equal("body", res)
+    end)
+  end)
+end)


### PR DESCRIPTION
Adding drolandos changes to the latest upstream fork as per EDGE-303.

-------

Remove mutex - use deque for speed - move implementation in init.lua
Use a simple counter to generate stream ids
try moving counter to the cluster level
Updated to work with lua-cassandra 1.5.0